### PR TITLE
Handle with deprecation warnings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -89,8 +89,8 @@ class ApplicationController < ActionController::Base
     Twitter::REST::Client.new do |config|
       config.consumer_key       = configatron.consumer_key
       config.consumer_secret    = configatron.consumer_secret
-      config.oauth_token        = user.token
-      config.oauth_token_secret = user.token_secret
+      config.access_token        = user.token
+      config.access_token_secret = user.token_secret
     end
   end
 

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -5,7 +5,7 @@ class Entity < ActiveRecord::Base
 
       # save given entities with its status_id linked
 
-      entities = status[:attrs][:entities]
+      entities = status.attrs[:entities]
 
       # save entities
       entities.each do |entity_type,entity_bodies|

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -36,7 +36,7 @@ class Status < ActiveRecord::Base
       Entity.save_entities(new_record.id.to_i,tweet)
 
       # save status's created_at values
-      PublicDate.add_record(Time.parse(tweet[:attrs][:created_at]).to_i)
+      PublicDate.add_record(Time.parse(tweet.attrs[:created_at]).to_i)
     end
 
     def get_date_list(type_of_timeline,user_id = nil)
@@ -117,7 +117,7 @@ class Status < ActiveRecord::Base
 
     def create_hash_to_save(user_id,tweet)
       ret = {}
-      tweet = tweet[:attrs]
+      tweet = tweet.attrs
 
       ret[:user_id] = user_id
       ret[:twitter_id] = tweet[:user][:id_str]


### PR DESCRIPTION
```
[DEPRECATION] #oauth_token= is deprecated. Use #access_token= instead.
[DEPRECATION] #oauth_token_secret= is deprecated. Use #access_token_secret= instead.
[DEPRECATION] #[:attrs] is deprecated. Use #attrs to fetch the value.
```